### PR TITLE
HTTP protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Miku Laitinen <miku@avoin.systems>
 
 RUN apk update \
     && apk add python py-pip \
-    && pip install boto3 requests \
+    && pip install boto3 requests ConfigArgParse \
     && apk add curl \
     && curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron \
     && chmod u+x /usr/local/bin/go-cron \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # odoo-backup-restore-s3
-Author: Miku Laitinen / [Avoin.Systems](https://avoin.systems)
+Authors: 
+ - Miku Laitinen / [Avoin.Systems](https://avoin.systems)
+ - Atte Isopuro / [Avoin.Systems](https://avoin.systems)
 
 Backup Odoo databases (with filestore) to S3 and restore them upon request. Supported Odoo versions: 8, 9, 10.
 [![Docker Repository on Quay](https://quay.io/repository/avoinsystems/odoo-backup-restore-s3/status "Docker Repository on Quay")](https://quay.io/repository/avoinsystems/odoo-backup-restore-s3)

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Configuration options can be passed as environment variables.
 | `DATABASES`             | A single database or comma-separated list of databases   |   |
 | `AWS_ACCESS_KEY_ID`     | Amazon AWS Access Key ID  |          |
 | `AWS_SECRET_ACCESS_KEY` | Amazon AWS Secret Access Key |       |
-| `AWS_REGION`            | The default AWS region       |`eu-central-1`   |
+| `AWS_REGION`            | The default AWS region       |  |
 | `S3_BUCKET`             | Amazon AWS S3 bucket name    |  |
 | `S3_PATH`               | The backup path inside the bucket, a.k.a. prefix   |`backup`   |
 | `RESTORE_FILENAME`      | Which backup file to restore. Only used when restoring backup.  If empty, the latest backup will be restored |   |
 | `SCHEDULE`              | Backup frequency. `single` = backup only once. See all available options [here](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules).  |`single`   |
-| `CHECK_URL`             | A URL to call after a successful backup   |   |
-| `PROTOCOL`              | The protocol to use (`xmlrpc`, `http`). HTTP is more memory-efficient but also somewhat hackier. | `xmlrpc` |
+| `CHECK_URL`             | A URL to call with a GET request after a successful backup   |   |
+| `PROTOCOL`              | The protocol to use (`xmlrpc`, `http`). HTTP is more memory-efficient. | `xmlrpc` |

--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ Configuration options can be passed as environment variables.
 | `RESTORE_FILENAME`      | Which backup file to restore. Only used when restoring backup.  If empty, the latest backup will be restored |   |
 | `SCHEDULE`              | Backup frequency. `single` = backup only once. See all available options [here](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules).  |`single`   |
 | `CHECK_URL`             | A URL to call after a successful backup   |   |
+| `PROTOCOL`              | The protocol to use (`xmlrpc`, `http`). HTTP is more memory-efficient but also somewhat hackier. | `xmlrpc` |

--- a/backup.py
+++ b/backup.py
@@ -259,19 +259,16 @@ if __name__ == "__main__":
     env = os.environ
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--databases', required=True, default=env.get('DATABASES'), type=lambda s: s.split(','))
+    parser.add_argument('--databases', default=env.get('DATABASES'), type=lambda s: s.split(','))
     parser.add_argument('--odoo-host', default=env.get('ODOO_HOST', 'localhost'))
     parser.add_argument('--odoo-port', default=env.get('ODOO_PORT', 8069))
-    parser.add_argument('--odoo-master-password', required=True,
-                        default=env.get('ODOO_MASTER_PASSWORD'))
-    parser.add_argument('--odoo-version', required=True, default=env.get('ODOO_VERSION'))
-    parser.add_argument('--aws-access-key-id', required=True,
-                        default=env.get('AWS_ACCESS_KEY_ID'))
-    parser.add_argument('--aws-secret-access-key', required=True,
-                        default=env.get('AWS_SECRET_ACCESS_KEY'))
-    parser.add_argument('--aws-region', required=True, default=env.get('AWS_REGION'))
-    parser.add_argument('--s3-bucket', required=True, default=env.get('S3_BUCKET'))
-    parser.add_argument('--s3-path', required=True, default=env.get('S3_PATH'))
+    parser.add_argument('--odoo-master-password', default=env.get('ODOO_MASTER_PASSWORD'))
+    parser.add_argument('--odoo-version', default=env.get('ODOO_VERSION'))
+    parser.add_argument('--aws-access-key-id', default=env.get('AWS_ACCESS_KEY_ID'))
+    parser.add_argument('--aws-secret-access-key', default=env.get('AWS_SECRET_ACCESS_KEY'))
+    parser.add_argument('--aws-region', default=env.get('AWS_REGION'))
+    parser.add_argument('--s3-bucket', default=env.get('S3_BUCKET'))
+    parser.add_argument('--s3-path', default=env.get('S3_PATH'))
     parser.add_argument('--check-url', default=env.get('CHECK_URL'))
     parser.add_argument('--restore-filename', default=env.get('RESTORE_FILENAME'))
     parser.add_argument('--protocol', default=env.get('PROTOCOL', 'xmlrpc'), choices=('xmlprc', 'http'))

--- a/backup.py
+++ b/backup.py
@@ -189,11 +189,10 @@ def restore_http(s3, databases, odoo_host, odoo_port, odoo_master_password,
     base_url = 'http://{}:{}/web/database/'.format(odoo_host, odoo_port)
 
     # Get the database list
-    # TODO: this returns a 400-error page, should be a json-rpc response. The body needs to be an empty object, that might be the problem
     response = requests.post(
         base_url + 'list',
         headers={'content-type': 'application/json'},
-        data={}
+        data='{}'
     )
 
     db_list = response.json()['result']


### PR DESCRIPTION
Backups can now be streamed directly from Odoo to S3 using the HTTP protocol. The streaming only works in this direction. Restoring a database via HTTP doesn't use streaming, but it uses a `TemporaryFile` instead of storing the entire database in memory, so HTTP mode is more useful for larger databases.